### PR TITLE
After all terms are converted, clean caches.

### DIFF
--- a/Taxonomy_Switcher.php
+++ b/Taxonomy_Switcher.php
@@ -247,7 +247,8 @@ class Taxonomy_Switcher {
 				WHERE `parent` = %d AND `term_id` IN ( {$term_ids} )
 			", $this->parent ) );
 		}
-
+		// Clean term caches
+		clean_term_cache( $term_ids, $this->to, true );
 		return true;
 	}
 }

--- a/Taxonomy_Switcher.php
+++ b/Taxonomy_Switcher.php
@@ -248,7 +248,8 @@ class Taxonomy_Switcher {
 			", $this->parent ) );
 		}
 		// Clean term caches
-		clean_term_cache( $term_ids, $this->to, true );
+		clean_term_cache( $term_ids, $this->from );
+		clean_term_cache( $term_ids, $this->to );
 		return true;
 	}
 }


### PR DESCRIPTION
After all terms are converted, clean caches. Current if you are using any object caching plugin or have other caches, these are not invalidated after the conversion is run. 