### PR TITLE
bump tested up to version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: webdevstudios, pluginize, sc0ttkclark, jtsternberg
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=3084056
 Tags: taxonomy, taxonomies, term, terms, category, categories, convert, converter, tag, tags, custom taxonomy, custom taxonomies, switch taxonomies
 Requires at least: 5.2
-Tested up to: 5.8.1
+Tested up to: 6.2.1
 Stable tag: 1.0.4
 License: GNU AGPLv3
 License URI: http://www.gnu.org/licenses/agpl-3.0.html


### PR DESCRIPTION
Bump tested up to version 6.2.1

It is tested up to 6.2.1 using version and PHP version 8.0

No errors or warnings related to taxonomy switcher plugin were found.

We are safe to say it works with the latest version.